### PR TITLE
Add Webviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,35 @@ Command.register('listNamespaces', async ({ withClient }) => {
 
 ## Components
 
+### Webviews
+
+`Webview` provides a wrapper around VS Code's terminal API with enhanced functionality and support for loading React components.
+
+```ts
+import { Command } from '$components/command';
+import { Webview } from '$components/webview';
+
+/**
+ * @summary Start a new workflow
+ * @description This command opens a webview to start a new workflow.
+ */
+Command.register('startWorkflow', async () => {
+  new Webview('Start Workflow', { component: 'start-workflow' });
+});
+```
+
+This will go looking for a React component in `src/webviews/start-workflow.tsx`.
+
+```tsx
+import React from 'react';
+
+export default function startWorkflow() {
+  return <p>Start Workflow</p>;
+}
+```
+
+This file must export the component as its default export.
+
 ### Terminal
 
 `Terminal` provides a wrapper around VS Code's terminal API with enhanced functionality:

--- a/build.ts
+++ b/build.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { watch } from 'node:fs/promises';
 
 const args = {
   production:
@@ -35,7 +36,7 @@ const buildConfig = {
 async function build() {
   const startTime = performance.now();
   log.info(
-    `Building extension in ${args.production ? 'production' : 'development'} mode...`,
+    `Building extension in ${chalk.bgBlue(args.production ? 'production' : 'development')} mode…`,
   );
 
   try {
@@ -64,6 +65,28 @@ async function build() {
     log.error('Build failed with an unexpected error:');
     log.error(error);
     process.exit(1);
+  }
+}
+
+if (args.watch) {
+  log.info('Watching for file changes…');
+
+  const watcher = watch('src', {
+    recursive: true,
+  });
+
+  for await (const event of watcher) {
+    if (event.eventType === 'change') {
+      log.build(
+        'File changed:',
+        chalk.magenta(event.filename),
+        chalk.yellow(event.eventType),
+      );
+      if (args.watch) {
+        log.info(chalk.green('Rebuilding…'));
+        build();
+      }
+    }
   }
 }
 

--- a/build.ts
+++ b/build.ts
@@ -30,6 +30,9 @@ const buildConfig = {
   external: ['vscode'],
   splitting: false,
   env: 'inline',
+  loader: {
+    '.html': 'text',
+  },
   target: 'node',
 } satisfies Bun.BuildConfig;
 

--- a/build.ts
+++ b/build.ts
@@ -27,6 +27,7 @@ const webview: BunPlugin = {
       const source = await Bun.file(args.path).text();
 
       const s = new MagicString(source);
+
       s.append('\n');
       s.append('export { React };\n');
       s.append(`export { createRoot } from 'react-dom/client';\n`);

--- a/build.ts
+++ b/build.ts
@@ -64,9 +64,13 @@ async function build() {
   } catch (error) {
     log.error('Build failed with an unexpected error:');
     log.error(error);
-    process.exit(1);
+    if (!args.watch) {
+      process.exit(1);
+    }
   }
 }
+
+build();
 
 if (args.watch) {
   log.info('Watching for file changes…');
@@ -77,7 +81,8 @@ if (args.watch) {
 
   for await (const event of watcher) {
     if (event.eventType === 'change') {
-      log.build(
+      //bun.sh/docs/runtime/bunfig#loader
+      https: log.build(
         'File changed:',
         chalk.magenta(event.filename),
         chalk.yellow(event.eventType),
@@ -89,10 +94,3 @@ if (args.watch) {
     }
   }
 }
-
-// Run the build
-build().catch((error) => {
-  log.error('Unhandled error during build:');
-  log.error(error);
-  process.exit(1);
-});

--- a/build.ts
+++ b/build.ts
@@ -1,4 +1,6 @@
+import { BunPlugin } from 'bun';
 import chalk from 'chalk';
+import MagicString from 'magic-string';
 import { watch } from 'node:fs/promises';
 
 const args = {
@@ -7,6 +9,34 @@ const args = {
     process.env.NODE_ENV === 'production',
   watch: process.argv.includes('--watch'),
   verbose: process.argv.includes('--verbose'),
+};
+
+const handleError =
+  (type: string) =>
+  (...error: unknown[]) => {
+    log.error(chalk.bgRed(type), ...error);
+    if (!args.watch) {
+      process.exit(1);
+    }
+  };
+
+const webview: BunPlugin = {
+  name: 'webviews',
+  setup(build) {
+    build.onLoad({ filter: /\.tsx$/ }, async (args) => {
+      const source = await Bun.file(args.path).text();
+
+      const s = new MagicString(source);
+      s.append('\n');
+      s.append('export { React };\n');
+      s.append(`export { createRoot } from 'react-dom/client';\n`);
+
+      return {
+        contents: s.toString(),
+        loader: 'tsx',
+      };
+    });
+  },
 };
 
 // Logger with color-coded categories
@@ -30,13 +60,10 @@ const buildConfig = {
   external: ['vscode'],
   splitting: false,
   env: 'inline',
-  loader: {
-    '.html': 'text',
-  },
   target: 'node',
 } satisfies Bun.BuildConfig;
 
-async function build() {
+async function build(withWebviews = false) {
   const startTime = performance.now();
   log.info(
     `Building extension in ${chalk.bgBlue(args.production ? 'production' : 'development')} mode…`,
@@ -46,17 +73,13 @@ async function build() {
     const result = await Bun.build(buildConfig);
 
     if (!result.success) {
-      log.error('Build failed');
-      for (const message of result.logs) {
-        log.error(message);
-      }
-      process.exit(1);
+      return handleError('Extension Build Failed')(...result.logs);
     }
 
     const endTime = performance.now();
     const buildTime = (endTime - startTime).toFixed(0);
 
-    log.success(`Build completed in ${buildTime}ms`);
+    log.success(`Build completed in ${chalk.yellow(buildTime)}ms`);
 
     if (args.verbose) {
       log.info('Output files:');
@@ -64,16 +87,56 @@ async function build() {
         log.info(`- ${output.path}`);
       }
     }
-  } catch (error) {
-    log.error('Build failed with an unexpected error:');
-    log.error(error);
-    if (!args.watch) {
-      process.exit(1);
+
+    if (withWebviews) {
+      await buildWebviews();
     }
+  } catch (error) {
+    handleError('Extension Build Failed')(error);
   }
 }
 
-build();
+async function buildWebviews() {
+  const webviews = new Bun.Glob('src/webviews/**/*.tsx');
+
+  log.info('Building webviews…');
+
+  for await (const file of webviews.scan()) {
+    await buildWebview(file);
+  }
+}
+
+async function buildWebview(file: string) {
+  const filePath = file.replace('src/webviews/', '');
+  const outputPath = `dist/${filePath.replace('.tsx', '.js')}`;
+
+  log.build(`Building webview: ${chalk.blue(filePath)}…`);
+
+  const result = await Bun.build({
+    entrypoints: [file],
+    format: 'esm',
+    naming: '[name].js',
+    minify: args.production,
+    sourcemap: args.production ? 'none' : 'inline',
+    outdir: 'dist',
+    splitting: false,
+    plugins: [webview],
+    env: 'inline',
+    target: 'browser',
+  });
+
+  if (!result.success) {
+    log.error(`Build failed for ${chalk.magenta(filePath)}`);
+    for (const message of result.logs) {
+      log.error(message);
+    }
+    handleError('Webview Build Failed')(...result.logs);
+  }
+
+  log.success(`Built ${chalk.cyan(filePath)} to ${chalk.cyan(outputPath)}.`);
+}
+
+build(true);
 
 if (args.watch) {
   log.info('Watching for file changes…');
@@ -85,15 +148,21 @@ if (args.watch) {
   for await (const event of watcher) {
     if (event.eventType === 'change') {
       //bun.sh/docs/runtime/bunfig#loader
-      https: log.build(
+      log.build(
         'File changed:',
         chalk.magenta(event.filename),
         chalk.yellow(event.eventType),
       );
-      if (args.watch) {
-        log.info(chalk.green('Rebuilding…'));
-        build();
+
+      if (event.filename?.endsWith('.tsx')) {
+        log.info(
+          chalk.yellow('Rebuilding webview…', chalk.magenta(event.filename)),
+        );
+        await buildWebview(event.filename);
       }
+
+      log.info(chalk.green('Rebuilding…'));
+      build();
     }
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,11 @@
     "": {
       "name": "temporal-vscode-extension",
       "dependencies": {
+        "@types/react": "^19.1.2",
+        "@types/react-dom": "^19.1.3",
+        "app-root-path": "^3.1.0",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
         "which": "^5.0.0",
       },
       "devDependencies": {
@@ -24,6 +29,7 @@
         "eslint": "^9.25.1",
         "globals": "^16.0.0",
         "json-schema-to-zod": "^2.6.1",
+        "magic-string": "^0.30.17",
         "npm-run-all": "^4.1.5",
         "pluralize": "^8.0.0",
         "prettier": "^3.5.3",
@@ -129,6 +135,10 @@
 
     "@types/pluralize": ["@types/pluralize@0.0.33", "", {}, "sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg=="],
 
+    "@types/react": ["@types/react@19.1.2", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw=="],
+
+    "@types/react-dom": ["@types/react-dom@19.1.3", "", { "peerDependencies": { "@types/react": "^19.0.0" } }, "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg=="],
+
     "@types/vscode": ["@types/vscode@1.99.1", "", {}, "sha512-cQlqxHZ040ta6ovZXnXRxs3fJiTmlurkIWOfZVcLSZPcm9J4ikFpXuB7gihofGn5ng+kDVma5EmJIclfk0trPQ=="],
 
     "@types/vscode-webview": ["@types/vscode-webview@1.57.5", "", {}, "sha512-iBAUYNYkz+uk1kdsq05fEcoh8gJmwT3lqqFPN7MGyjQ3HVloViMdo7ZJ8DFIP8WOK74PjOEilosqAyxV2iUFUw=="],
@@ -172,6 +182,8 @@
     "ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "app-root-path": ["app-root-path@3.1.0", "", {}, "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -232,6 +244,8 @@
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
     "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
 
@@ -499,6 +513,8 @@
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
+
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
@@ -597,6 +613,10 @@
 
     "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
 
+    "react": ["react@19.1.0", "", {}, "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg=="],
+
+    "react-dom": ["react-dom@19.1.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g=="],
+
     "read-pkg": ["read-pkg@3.0.0", "", { "dependencies": { "load-json-file": "^4.0.0", "normalize-package-data": "^2.3.2", "path-type": "^3.0.0" } }, "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA=="],
 
     "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
@@ -626,6 +646,8 @@
     "safe-push-apply": ["safe-push-apply@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "isarray": "^2.0.5" } }, "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA=="],
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
+
+    "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
     "semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,11 +4,6 @@
     "": {
       "name": "temporal-vscode-extension",
       "dependencies": {
-        "@types/react": "^19.1.2",
-        "@types/react-dom": "^19.1.3",
-        "app-root-path": "^3.1.0",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
         "which": "^5.0.0",
       },
       "devDependencies": {
@@ -17,6 +12,8 @@
         "@temporalio/common": "^1.11.7",
         "@types/bun": "latest",
         "@types/pluralize": "^0.0.33",
+        "@types/react": "^19.1.2",
+        "@types/react-dom": "^19.1.3",
         "@types/vscode": "^1.99.1",
         "@types/vscode-webview": "^1.57.5",
         "@types/which": "^3.0.4",
@@ -33,6 +30,8 @@
         "npm-run-all": "^4.1.5",
         "pluralize": "^8.0.0",
         "prettier": "^3.5.3",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
         "ts-morph": "^25.0.1",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.31.1",
@@ -182,8 +181,6 @@
     "ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
-
-    "app-root-path": ["app-root-path@3.1.0", "", {}, "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 

--- a/package.json
+++ b/package.json
@@ -282,6 +282,7 @@
     "eslint": "^9.25.1",
     "globals": "^16.0.0",
     "json-schema-to-zod": "^2.6.1",
+    "magic-string": "^0.30.17",
     "npm-run-all": "^4.1.5",
     "pluralize": "^8.0.0",
     "prettier": "^3.5.3",
@@ -298,6 +299,11 @@
   ],
   "activationEvents": [],
   "dependencies": {
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.3",
+    "app-root-path": "^3.1.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "which": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "generate:commands": "bun run src/generate/commands",
     "generate:types": "bun run src/generate/types",
     "generate:configuration": "bun run src/generate/configuration",
-    "watch:build": "bun run --watch build",
+    "watch:build": "bun run build --watch",
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
     "package": "bun run check-types && bun run lint && bun run build --production",
     "compile:tests": "tsc -p . --outDir out",
@@ -90,6 +90,11 @@
       {
         "command": "temporal-vscode.changeDefaultNamespace.workspace",
         "title": "Change default namespace (Workspace)",
+        "category": "Temporal"
+      },
+      {
+        "command": "temporal-vscode.startWorkflow",
+        "title": "Start a new workflow",
         "category": "Temporal"
       },
       {
@@ -246,7 +251,12 @@
         "temporal.commandLine.logLevel": {
           "title": "CLI Log Level",
           "type": "string",
-          "enum": ["debug", "info", "warn", "error"],
+          "enum": [
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ],
           "default": "error",
           "description": "The log level to use for the Temporal CLI.",
           "order": 100
@@ -283,7 +293,9 @@
   "engines": {
     "vscode": "^1.92.0"
   },
-  "categories": ["Other"],
+  "categories": [
+    "Other"
+  ],
   "activationEvents": [],
   "dependencies": {
     "which": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -270,6 +270,8 @@
     "@temporalio/common": "^1.11.7",
     "@types/bun": "latest",
     "@types/pluralize": "^0.0.33",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.3",
     "@types/vscode": "^1.99.1",
     "@types/vscode-webview": "^1.57.5",
     "@types/which": "^3.0.4",
@@ -286,6 +288,8 @@
     "npm-run-all": "^4.1.5",
     "pluralize": "^8.0.0",
     "prettier": "^3.5.3",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "ts-morph": "^25.0.1",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.31.1",
@@ -299,11 +303,6 @@
   ],
   "activationEvents": [],
   "dependencies": {
-    "@types/react": "^19.1.2",
-    "@types/react-dom": "^19.1.3",
-    "app-root-path": "^3.1.0",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
     "which": "^5.0.0"
   }
 }

--- a/src/commands.d.ts
+++ b/src/commands.d.ts
@@ -15,6 +15,7 @@ type CommandName =
   | 'openSettings'
   | 'changeDefaultNamespace.user'
   | 'changeDefaultNamespace.workspace'
+  | 'startWorkflow'
   | 'showTaskQueue'
   | 'viewWorkflows'
   | 'openWorkflow'

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -14,6 +14,7 @@
 - **openSettings** Open settings
 - **changeDefaultNamespace.user** Change default namespace (User)
 - **changeDefaultNamespace.workspace** Change default namespace (Workspace)
+- **startWorkflow** Start a new workflow
 - **showTaskQueue** Show task queue in the UI
 - **viewWorkflows** View workflows in the UI
 - **openWorkflow** Open workflow in the UI

--- a/src/commands/start-workflow.ts
+++ b/src/commands/start-workflow.ts
@@ -6,5 +6,5 @@ import { Webview } from '$components/webview';
  * @description This command opens a webview to start a new workflow.
  */
 Command.register('startWorkflow', async () => {
-  new Webview('Start Workflow', { html: 'start-workflow' });
+  new Webview('Start Workflow', { component: 'start-workflow' });
 });

--- a/src/commands/start-workflow.ts
+++ b/src/commands/start-workflow.ts
@@ -1,0 +1,10 @@
+import { Command } from '$components/command';
+import { Webview } from '$components/webview';
+
+/**
+ * @summary Start a new workflow
+ * @description This command opens a webview to start a new workflow.
+ */
+Command.register('startWorkflow', async () => {
+  new Webview('Start Workflow', { html: 'start-workflow' });
+});

--- a/src/components/webview.ts
+++ b/src/components/webview.ts
@@ -13,14 +13,28 @@ type WebviewOptions = vscode.WebviewPanelOptions &
     hide?: boolean;
   };
 
+/**
+ * A listener for the webview panel's view state change event.
+ * This event is fired when the view state of the webview panel changes.
+ * For example, when the panel is activated or deactivated.
+ * The listener receives an event object that contains information about the view state change.
+ */
 type ViewStateChangeListener = (
   e: vscode.WebviewPanelOnDidChangeViewStateEvent,
 ) => void;
 
-type MessageListener = (
-  e: vscode.WebviewPanelOnDidChangeViewStateEvent,
-) => void;
+/**
+ * A listener for the webview panel's message event.
+ * This event is fired when a message is received from the webview.
+ * The listener receives an event object that contains the message data.
+ */
+type MessageListener = (message: any) => void;
 
+/**
+ * A listener for the webview panel's disposal event.
+ * This event is fired when the webview panel is disposed.
+ * The listener receives an event object that contains information about the disposal.
+ */
 type DisposalListener = () => void;
 
 /**
@@ -51,7 +65,7 @@ export class Webview
   #panel: vscode.WebviewPanel | null = null;
   #intervals: Set<NodeJS.Timeout> = new Set();
   #timeouts: Set<NodeJS.Timeout> = new Set();
-  #dispoalListeners: Set<DisposalListener> = new Set();
+  #disposalListeners: Set<DisposalListener> = new Set();
   #viewStateChangeListeners: Set<ViewStateChangeListener> = new Set();
   #messageListeners: Set<MessageListener> = new Set();
 
@@ -71,7 +85,7 @@ export class Webview
 
     this.title = title;
     this.viewType = viewType;
-    this.viewColumn = vscode.ViewColumn.Active;
+    this.viewColumn = viewColumn;
     this.preserveFocus = preserveFocus;
     this.messageSchema = messageSchema || z.any();
     this.html = html;
@@ -109,8 +123,7 @@ export class Webview
   }
 
   /**
-   * The URI that can be used to access the webview's content.
-   * This is the URI that can be used to access the webview's content.
+   * The Content Security Policy source for the webview.
    * @throws Error if the panel is not created yet.
    */
   get cspSource(): string {
@@ -121,8 +134,8 @@ export class Webview
   }
 
   /**
-   * The URI that can be used to access the webview's content.
-   * This is the URI that can be used to access the webview's content.
+   * Function to convert a URI for use within the webview.
+   * This allows resources to be loaded within the webview context.
    * @throws Error if the panel is not created yet.
    */
   get asWebviewUri(): (uri: vscode.Uri) => vscode.Uri {
@@ -133,10 +146,10 @@ export class Webview
   }
 
   /**
-   *
+   * Creates and reveals the webview panel if it doesn't exist, or reveals an existing panel.
    * @param viewColumn - The view column to show the webview in. If not provided, it will use the current view column.
-   * @param options - Additional options for the webview panel.
-   * @returns
+   * @param preserveFocus - Whether to preserve focus on the current editor after revealing.
+   * @returns The webview panel instance.
    */
   reveal(
     viewColumn = this.viewColumn,
@@ -158,7 +171,7 @@ export class Webview
       panel.onDidChangeViewState(listener);
     }
 
-    for (const listener of this.#dispoalListeners) {
+    for (const listener of this.#disposalListeners) {
       panel.onDidDispose(listener);
     }
 
@@ -289,6 +302,7 @@ export class Webview
    * It should be called when the webview is closed or when the extension is deactivated.
    */
   dispose(): void {
+    // Remove the panel first to prevent further event triggers
     this.#panel?.dispose();
     this.#panel = null;
 
@@ -302,18 +316,23 @@ export class Webview
 
     this.#timeouts.clear();
     this.#intervals.clear();
+    
+    // Clear all listener sets
+    this.#disposalListeners.clear();
+    this.#viewStateChangeListeners.clear();
+    this.#messageListeners.clear();
   }
 
   onDidDispose(listener: DisposalListener) {
-    this.#dispoalListeners.add(listener);
+    this.#disposalListeners.add(listener);
 
     const disposable = new vscode.Disposable(() => {
-      this.#viewStateChangeListeners.delete(listener);
+      this.#disposalListeners.delete(listener);
     });
 
     return {
       dispose: () => {
-        this.#viewStateChangeListeners.delete(listener);
+        this.#disposalListeners.delete(listener);
         disposable.dispose();
       },
     };

--- a/src/components/webview.ts
+++ b/src/components/webview.ts
@@ -167,6 +167,10 @@ export class Webview
       this.options,
     );
 
+    if (!panel.webview.html) {
+      panel.webview.html = this.html;
+    }
+
     for (const listener of this.#viewStateChangeListeners) {
       panel.onDidChangeViewState(listener);
     }

--- a/src/components/webview.ts
+++ b/src/components/webview.ts
@@ -1,0 +1,280 @@
+import * as vscode from 'vscode';
+import { Component } from './component';
+import { camelCase } from 'change-case';
+import { z } from 'zod';
+
+type WebviewOptions = vscode.WebviewPanelOptions &
+  vscode.WebviewOptions & {
+    viewType?: string;
+    viewColumn?: vscode.ViewColumn;
+    preserveFocus?: boolean;
+    messageSchema?: z.Schema;
+    html?: string;
+    hide?: boolean;
+  };
+
+type ViewStateChangeListener = (
+  e: vscode.WebviewPanelOnDidChangeViewStateEvent,
+) => void;
+
+type MessageListener = (
+  e: vscode.WebviewPanelOnDidChangeViewStateEvent,
+) => void;
+
+type DisposalListener = () => void;
+
+/**
+ * A class that represents a webview panel in Visual Studio Code.
+ * It provides methods to create, manage, and dispose of the webview panel.
+ * It also provides methods to set timeouts and intervals that are automatically cleared when the webview is disposed.
+ */
+export class Webview
+  extends Component
+  implements vscode.WebviewPanel, vscode.Webview
+{
+  title: string;
+  viewType: string;
+  viewColumn: vscode.ViewColumn;
+  preserveFocus?: boolean;
+  options: vscode.WebviewPanelOptions & vscode.WebviewOptions;
+  messageSchema: z.Schema;
+  html: string = '';
+
+  #panel: vscode.WebviewPanel | null = null;
+  #intervals: Set<NodeJS.Timeout> = new Set();
+  #timeouts: Set<NodeJS.Timeout> = new Set();
+  #dispoalListeners: Set<DisposalListener> = new Set();
+  #viewStateChangeListeners: Set<ViewStateChangeListener> = new Set();
+  #messageListeners: Set<MessageListener> = new Set();
+
+  constructor(
+    title: string,
+    {
+      viewType = camelCase(title),
+      viewColumn = vscode.ViewColumn.Active,
+      preserveFocus,
+      messageSchema,
+      hide = false,
+      html = '',
+      ...options
+    }: WebviewOptions = {},
+  ) {
+    super();
+
+    this.title = title;
+    this.viewType = viewType;
+    this.viewColumn = vscode.ViewColumn.Active;
+    this.preserveFocus = preserveFocus;
+    this.messageSchema = messageSchema || z.any();
+    this.html = html;
+    this.options = options;
+
+    if (!hide) this.reveal(viewColumn, preserveFocus);
+  }
+
+  get active(): boolean {
+    return this.#panel?.active ?? false;
+  }
+
+  get visible(): boolean {
+    return this.#panel?.visible ?? false;
+  }
+
+  get webview(): vscode.Webview {
+    if (!this.#panel) {
+      throw new Error(`Webview panel (${this.title}) is not created yet`);
+    }
+    return this.#panel.webview;
+  }
+
+  get cspSource(): string {
+    if (!this.#panel) {
+      throw new Error(`Webview panel (${this.title}) is not created yet`);
+    }
+    return this.#panel.webview.cspSource;
+  }
+
+  get asWebviewUri(): (uri: vscode.Uri) => vscode.Uri {
+    if (!this.#panel) {
+      throw new Error(`Webview panel (${this.title}) is not created yet`);
+    }
+    return this.#panel.webview.asWebviewUri;
+  }
+
+  /**
+   *
+   * @param viewColumn - The view column to show the webview in. If not provided, it will use the current view column.
+   * @param options - Additional options for the webview panel.
+   * @returns
+   */
+  reveal(
+    viewColumn = this.viewColumn,
+    preserveFocus?: boolean,
+  ): vscode.WebviewPanel {
+    if (this.#panel) {
+      this.#panel.reveal(viewColumn, preserveFocus);
+      return this.#panel;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      this.viewType,
+      this.title,
+      { viewColumn, preserveFocus },
+      this.options,
+    );
+
+    for (const listener of this.#viewStateChangeListeners) {
+      panel.onDidChangeViewState(listener);
+    }
+
+    for (const listener of this.#dispoalListeners) {
+      panel.onDidDispose(listener);
+    }
+
+    for (const listener of this.#messageListeners) {
+      panel.webview.onDidReceiveMessage(listener);
+    }
+
+    panel.onDidDispose(() => {
+      this.dispose();
+    });
+
+    return panel;
+  }
+
+  postMessage(message: z.infer<typeof this.messageSchema>) {
+    const panel = this.#panel || this.reveal();
+    return panel.webview.postMessage(message);
+  }
+
+  /**
+   * Executes a function after a specified delay.
+   * This method is similar to the built-in `setTimeout` function, but it also keeps track of the timeouts created.
+   * It allows you to clear all timeouts when the webview is disposed.
+   * @param fn - The function to execute after the delay.
+   * @param delay - The delay in milliseconds before executing the function.
+   * @param args - The arguments to pass to the function when it is executed
+   */
+  setTimeout(
+    fn: (...args: any[]) => void,
+    delay: number,
+    ...args: any[]
+  ): NodeJS.Timeout {
+    const timeout = setTimeout(() => {
+      fn(...args);
+      this.#timeouts.delete(timeout);
+    }, delay);
+    this.#timeouts.add(timeout);
+    return timeout;
+  }
+
+  /**
+   * Clears the specified timeout.
+   * This method is similar to the built-in `clearTimeout` function, but it also removes the timeout from the set of timeouts.
+   * @param timeout - The timeout to clear.
+   */
+  clearTimeout(timeout: NodeJS.Timeout): void {
+    clearTimeout(timeout);
+    this.#timeouts.delete(timeout);
+  }
+
+  /**
+   * Executes a function on a regular interval.
+   * This method is similar to the built-in `setInterval` function, but it also keeps track of the timeouts created.
+   * It allows you to clear all timeouts when the webview is disposed.
+   * @param fn - The function to execute after the delay.
+   * @param delay - The delay in milliseconds before executing the function.
+   * @param args - The arguments to pass to the function when it is executed
+   */
+  setInterval(
+    fn: (...args: any[]) => void,
+    delay: number,
+    ...args: any[]
+  ): NodeJS.Timeout {
+    const interval = setInterval(() => {
+      fn(...args);
+    }, delay);
+    this.#intervals.add(interval);
+    return interval;
+  }
+
+  /**
+   * Clears the specified interval.
+   * This method is similar to the built-in `clearInterval` function, but it also removes the interval from the set of intervals.
+   * @param interval - The interval to clear.
+   */
+  clearInterval(interval: NodeJS.Timeout): void {
+    clearInterval(interval);
+    this.#intervals.delete(interval);
+  }
+
+  onDidReceiveMessage(listener: MessageListener): vscode.Disposable {
+    this.#messageListeners.add(listener);
+
+    const disposable = new vscode.Disposable(() => {
+      this.#messageListeners.delete(listener);
+    });
+
+    return {
+      dispose: () => {
+        this.#messageListeners.delete(listener);
+        disposable.dispose();
+      },
+    };
+  }
+
+  /**
+   * Registers a listener that is invoked whenever the webview panel's view state changes.
+   */
+  onDidChangeViewState(listener: ViewStateChangeListener): vscode.Disposable {
+    this.#viewStateChangeListeners.add(listener);
+
+    const disposable = new vscode.Disposable(() => {
+      this.#viewStateChangeListeners.delete(listener);
+    });
+
+    return {
+      dispose: () => {
+        this.#viewStateChangeListeners.delete(listener);
+        disposable.dispose();
+      },
+    };
+  }
+
+  /**
+   * Close the webview panel and clean up resources.
+   * This method is called when the webview is no longer needed.
+   * It disposes of the webview and clears any intervals or timeouts.
+   * It should be called when the webview is closed or when the extension is deactivated.
+   */
+  dispose(): void {
+    this.#panel?.dispose();
+    this.#panel = null;
+
+    for (const timeout of this.#timeouts) {
+      this.clearTimeout(timeout);
+    }
+
+    for (const interval of this.#intervals) {
+      this.clearInterval(interval);
+    }
+
+    this.#timeouts.clear();
+    this.#intervals.clear();
+  }
+
+  onDidDispose(listener: DisposalListener) {
+    this.#dispoalListeners.add(listener);
+
+    const disposable = new vscode.Disposable(() => {
+      this.#viewStateChangeListeners.delete(listener);
+    });
+
+    return {
+      dispose: () => {
+        this.#viewStateChangeListeners.delete(listener);
+        disposable.dispose();
+      },
+    };
+  }
+}

--- a/src/components/webview.ts
+++ b/src/components/webview.ts
@@ -316,7 +316,7 @@ export class Webview
 
     this.#timeouts.clear();
     this.#intervals.clear();
-    
+
     // Clear all listener sets
     this.#disposalListeners.clear();
     this.#viewStateChangeListeners.clear();

--- a/src/components/webview.ts
+++ b/src/components/webview.ts
@@ -112,7 +112,7 @@ export class Webview
       `</script>`,
     ].join('\n');
 
-    panel.webview.component = this.#html;
+    panel.webview.html = this.#html;
   }
 
   get component(): string {

--- a/src/components/webview.ts
+++ b/src/components/webview.ts
@@ -9,10 +9,8 @@ type WebviewOptions = vscode.WebviewPanelOptions &
     viewColumn?: vscode.ViewColumn;
     preserveFocus?: boolean;
     messageSchema?: z.Schema;
-    /** The HTML content of the webview panel. The panel will be hidden by default if this is not set at initialization. */
-    html?: string;
-    /** Hide the webview until `.reveal` is called. `true` if `html` is falsey. */
-    hide?: boolean;
+    /** A reference to a JSX component found in `src/webviews`. */
+    component: string;
   };
 
 /**
@@ -62,7 +60,7 @@ export class Webview
   /** Zod schema to validate messages sent to the webview. */
   messageSchema: z.Schema;
   /** The HTML content of the webview panel. */
-  html: string = '';
+  #html: string = '';
 
   #panel: vscode.WebviewPanel | null = null;
   #intervals: Set<NodeJS.Timeout> = new Set();
@@ -78,11 +76,11 @@ export class Webview
       viewColumn = vscode.ViewColumn.Active,
       preserveFocus,
       messageSchema,
-      html = '',
-      hide = !!html,
+      component,
       retainContextWhenHidden = true,
+      enableScripts = true,
       ...options
-    }: WebviewOptions = {},
+    }: WebviewOptions,
   ) {
     super();
 
@@ -91,10 +89,34 @@ export class Webview
     this.viewColumn = viewColumn;
     this.preserveFocus = preserveFocus;
     this.messageSchema = messageSchema || z.any();
-    this.html = html;
-    this.options = { retainContextWhenHidden, ...options };
+    this.options = { retainContextWhenHidden, enableScripts, ...options };
 
-    if (!hide) this.reveal(viewColumn, preserveFocus);
+    this.component = component;
+  }
+
+  set component(html: string) {
+    const panel = this.reveal();
+    const uri = vscode.Uri.joinPath(
+      this.context.extensionUri,
+      'dist',
+      `${html}.js`,
+    );
+    const path = panel.webview.asWebviewUri(uri);
+
+    this.#html = [
+      `<div id="root"></div>`,
+      `<script type="module">`,
+      `   import Component, { createRoot, React } from '${path.toString()}';`,
+      `   const root = createRoot(document.getElementById('root'));`,
+      `   root.render(React.createElement(Component, null));`,
+      `</script>`,
+    ].join('\n');
+
+    panel.webview.component = this.#html;
+  }
+
+  get component(): string {
+    return this.#html;
   }
 
   /**
@@ -169,10 +191,6 @@ export class Webview
       { viewColumn, preserveFocus },
       this.options,
     );
-
-    if (!panel.webview.html) {
-      panel.webview.html = this.html;
-    }
 
     for (const listener of this.#viewStateChangeListeners) {
       panel.onDidChangeViewState(listener);

--- a/src/components/webview.ts
+++ b/src/components/webview.ts
@@ -89,7 +89,7 @@ export class Webview
     this.preserveFocus = preserveFocus;
     this.messageSchema = messageSchema || z.any();
     this.html = html;
-    this.options = options;
+    this.options = { retainContextWhenHidden, ...options };
 
     if (!hide) this.reveal(viewColumn, preserveFocus);
   }

--- a/src/components/webview.ts
+++ b/src/components/webview.ts
@@ -9,7 +9,9 @@ type WebviewOptions = vscode.WebviewPanelOptions &
     viewColumn?: vscode.ViewColumn;
     preserveFocus?: boolean;
     messageSchema?: z.Schema;
+    /** The HTML content of the webview panel. The panel will be hidden by default if this is not set at initialization. */
     html?: string;
+    /** Hide the webview until `.reveal` is called. `true` if `html` is falsey. */
     hide?: boolean;
   };
 
@@ -76,8 +78,9 @@ export class Webview
       viewColumn = vscode.ViewColumn.Active,
       preserveFocus,
       messageSchema,
-      hide = false,
       html = '',
+      hide = !!html,
+      retainContextWhenHidden = true,
       ...options
     }: WebviewOptions = {},
   ) {

--- a/src/components/webview.ts
+++ b/src/components/webview.ts
@@ -27,17 +27,25 @@ type DisposalListener = () => void;
  * A class that represents a webview panel in Visual Studio Code.
  * It provides methods to create, manage, and dispose of the webview panel.
  * It also provides methods to set timeouts and intervals that are automatically cleared when the webview is disposed.
+ * It's effectively a wrapper around the `vscode.WebviewPanel` and `vscode.Webview` classes.
  */
 export class Webview
   extends Component
   implements vscode.WebviewPanel, vscode.Webview
 {
+  /** The title of the webview panel. */
   title: string;
+  /** The type of the webview panel. */
   viewType: string;
+  /** The view column in which the webview panel is displayed. */
   viewColumn: vscode.ViewColumn;
+  /** Whether the webview panel should preserve focus when revealed. */
   preserveFocus?: boolean;
+  /** Whether the webview panel should be created at initialization. */
   options: vscode.WebviewPanelOptions & vscode.WebviewOptions;
+  /** Zod schema to validate messages sent to the webview. */
   messageSchema: z.Schema;
+  /** The HTML content of the webview panel. */
   html: string = '';
 
   #panel: vscode.WebviewPanel | null = null;
@@ -72,14 +80,27 @@ export class Webview
     if (!hide) this.reveal(viewColumn, preserveFocus);
   }
 
+  /**
+   * Whether the panel is active (focused by the user).
+   * This property is `true` if the panel is currently active and `false` otherwise.
+   */
   get active(): boolean {
     return this.#panel?.active ?? false;
   }
 
+  /**
+   * Whether the panel is visible.
+   * This property is `true` if the panel is currently visible and `false` otherwise.
+   */
   get visible(): boolean {
     return this.#panel?.visible ?? false;
   }
 
+  /**
+   * `Webview` belonging to the panel.
+   * This is the webview that is displayed in the panel.
+   * @throws Error if the panel is not created yet.
+   */
   get webview(): vscode.Webview {
     if (!this.#panel) {
       throw new Error(`Webview panel (${this.title}) is not created yet`);
@@ -87,6 +108,11 @@ export class Webview
     return this.#panel.webview;
   }
 
+  /**
+   * The URI that can be used to access the webview's content.
+   * This is the URI that can be used to access the webview's content.
+   * @throws Error if the panel is not created yet.
+   */
   get cspSource(): string {
     if (!this.#panel) {
       throw new Error(`Webview panel (${this.title}) is not created yet`);
@@ -94,6 +120,11 @@ export class Webview
     return this.#panel.webview.cspSource;
   }
 
+  /**
+   * The URI that can be used to access the webview's content.
+   * This is the URI that can be used to access the webview's content.
+   * @throws Error if the panel is not created yet.
+   */
   get asWebviewUri(): (uri: vscode.Uri) => vscode.Uri {
     if (!this.#panel) {
       throw new Error(`Webview panel (${this.title}) is not created yet`);
@@ -142,6 +173,16 @@ export class Webview
     return panel;
   }
 
+  /**
+   * Post a message to the webview content.
+   * Messages are only sent if the webview is live (either visible or in the background with `retainContextWhenHidden`).
+   *
+   * The message is validated against the provided Zod schema, `this.messageSchema`.
+   * If the message is not valid, an error is thrown.
+   *
+   * @param message
+   * @returns
+   */
   postMessage(message: z.infer<typeof this.messageSchema>) {
     const panel = this.#panel || this.reveal();
     return panel.webview.postMessage(message);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ export async function activate(context: vscode.ExtensionContext) {
     await Promise.all([
       import('./commands/workflows'),
       import('./commands/count-workflows'),
+      import('./commands/start-workflow'),
       import('./commands/task-queue'),
       import('./commands/schedules'),
       import('./commands/batch-operations'),

--- a/src/generate/commands/command-registration.ts
+++ b/src/generate/commands/command-registration.ts
@@ -95,7 +95,7 @@ export class CommandRegistration {
     const [documentation] = this.#expressionStatement.getJsDocs();
 
     if (!documentation) {
-      throw new Error('No documentation found');
+      throw new Error(`No documentation found for the command: ${this.name}`);
     }
 
     for (const tag of documentation.getTags()) {

--- a/src/webviews/start-workflow.tsx
+++ b/src/webviews/start-workflow.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function startWorkflow() {
+  return <p>Start Workflow</p>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUnusedParameters": true,
     "skipLibCheck": true,
+    "jsx": "react-jsx",
     "paths": {
       "$utilities/*": ["./src/utilities/*"],
       "$commands/*": ["./src/commands/*"],


### PR DESCRIPTION
Sets up an abstractions over `vscode.WebView` that implements from of the best practices from the [documentation](https://code.visualstudio.com/api/extension-guides/webview) and also provides some convenience.

- [x] Get the basic abstraction in place.
- [x] Create a system for loading HTML files without needing to manually edit a long string.
- [x] Create easy to load in either Svelte or React components.

## Example Usage

```ts
import { Command } from '$components/command';
import { Webview } from '$components/webview';

/**
 * @summary Start a new workflow
 * @description This command opens a webview to start a new workflow.
 */
Command.register('startWorkflow', async () => {
  new Webview('Start Workflow', { component: 'start-workflow' });
});
```

This will go looking for a React component in `src/webviews/start-workflow.tsx`.

```tsx
import React from 'react';

export default function startWorkflow() {
  return <p>Start Workflow</p>;
}
```

This file must export the component as its default export.